### PR TITLE
OpenCV 3.3.0 Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
+.DS_Store # Mac users
 .vagrant
+build
 downloads
 *.tar.gz
 
-opencv-3.2.0
-
+opencv-*

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-OpenCV 3.2.0 build for RoboRIO
+OpenCV 3.3.0 build for RoboRIO
 ==============================
 
 This is a set of scripts that will build OpenCV for the RoboRIO with bindings for:
@@ -33,7 +33,7 @@ For Python3:
 For C++:
 
     opkg install opencv3
-    
+
 ~~For Java (Java programming support must be installed separately)~~:
 
     opkg install opencv3-java
@@ -45,7 +45,7 @@ You can use the [RobotPy Installer Script](https://github.com/robotpy/robotpy-wp
 to do offline opkg installs. First, download the package:
 
     python3 installer.py download-opkg opencv3
-    
+
 Then, connect to the network with the RoboRIO, and install it:
 
     python3 installer.py install-opkg opencv3
@@ -65,7 +65,7 @@ Using the Python bindings
 -------------------------
 
 See the image processing section of the Programmer's Guide at the [RobotPy documentation site](http://robotpy.readthedocs.io)
-for details. 
+for details.
 
 Building your own version of OpenCV
 ===================================
@@ -89,7 +89,7 @@ following:
 
     sudo ./fetch.sh
     ./build.sh
-    
+
 But... I'd recommend using the VM instead.
 
 Troubleshooting

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-OPENCV_VERSION=3.2.0
+OPENCV_VERSION=3.3.0
 PYTHON_VERSION=3.6
 
 pushd `dirname $0`
@@ -14,15 +14,12 @@ CVDIR="$ROOT"/opencv-${OPENCV_VERSION}
 function unpack_download {
   FNAME=$(basename $1)
   EXT="${FNAME##*.}"
-  
-  case "$EXT" in 
+
+  case "$EXT" in
     "ipk")
       ar -x "$ROOT"/downloads/"$FNAME"
       tar -xf data.tar.gz -C "$SYSROOT"
-      rm data.tar.gz control.tar.gz debian-binary 
-      ;;
-    "whl")
-      unzip "$ROOT"/downloads/"$FNAME" -d "$PYTHON3_SITE_PACKAGES"
+      rm data.tar.gz control.tar.gz debian-binary
       ;;
     *)
       echo "$FNAME has unknown file type '$EXT' to unpack"
@@ -38,10 +35,10 @@ function assert_path {
   fi
 }
 
-if [ -z "$JAVA_HOME" ]; then
-  echo "ERROR: JAVA_HOME not set! (maybe you need to do '. /etc/profile', or logout/login)"
-  exit 1
-fi
+# if [ -z "$JAVA_HOME" ]; then
+#   echo "ERROR: JAVA_HOME not set! (maybe you need to do '. /etc/profile', or logout/login)"
+#   exit 1
+# fi
 
 sed -i 's/arm-linux-gnueabi/arm-frc-linux-gnueabi/g' "$CVDIR"/platforms/linux/arm-gnueabi.toolchain.cmake
 
@@ -87,6 +84,5 @@ fi
 make $MAKEARGS
 
 cpack -G TGZ
-mv OpenCV-${OPENCV_VERSION}-.tar.gz /vagrant/OpenCV-${OPENCV_VERSION}-cortexa9-vfpv3.tar.g
-
+mv OpenCV-${OPENCV_VERSION}-cortexa9-vfpv3.tar.gz ${ROOT}/OpenCV-${OPENCV_VERSION}-cortexa9-vfpv3.tar.gz
 popd

--- a/deps
+++ b/deps
@@ -1,3 +1,3 @@
 http://www.tortall.net/~robotpy/feeds/2017/python36_3.6.0-r1_cortexa9-vfpv3.ipk
 http://www.tortall.net/~robotpy/feeds/2017/python36-dev_3.6.0-r1_cortexa9-vfpv3.ipk
-https://www.tortall.net/~robotpy/feeds/2017/python36-numpy_1.12.0_cortexa9-vfpv3.ipk
+http://www.tortall.net/~robotpy/feeds/2017/python36-numpy_1.12.0_cortexa9-vfpv3.ipk

--- a/deps
+++ b/deps
@@ -1,3 +1,3 @@
 http://www.tortall.net/~robotpy/feeds/2017/python36_3.6.0-r1_cortexa9-vfpv3.ipk
 http://www.tortall.net/~robotpy/feeds/2017/python36-dev_3.6.0-r1_cortexa9-vfpv3.ipk
-https://www.tortall.net/~robotpy/wheels/2017/numpy-1.12.0-cp36-cp36m-linux_armv7l.whl
+https://www.tortall.net/~robotpy/feeds/2017/python36-numpy_1.12.0_cortexa9-vfpv3.ipk

--- a/deps
+++ b/deps
@@ -1,3 +1,3 @@
-http://www.tortall.net/~robotpy/feeds/2017/python36_3.6.0-r1_cortexa9-vfpv3.ipk
-http://www.tortall.net/~robotpy/feeds/2017/python36-dev_3.6.0-r1_cortexa9-vfpv3.ipk
-http://www.tortall.net/~robotpy/feeds/2017/python36-numpy_1.12.0_cortexa9-vfpv3.ipk
+https://www.tortall.net/~robotpy/feeds/2017/python36_3.6.0-r1_cortexa9-vfpv3.ipk
+https://www.tortall.net/~robotpy/feeds/2017/python36-dev_3.6.0-r1_cortexa9-vfpv3.ipk
+https://www.tortall.net/~robotpy/feeds/2017/python36-numpy_1.12.0_cortexa9-vfpv3.ipk

--- a/fetch.sh
+++ b/fetch.sh
@@ -1,13 +1,13 @@
 #!/bin/bash -e
 
-OPENCV_VERSION=3.2.0
+OPENCV_VERSION=3.3.0
 
 cd `dirname $0`
 
 function download {
   URI="$1"
   FNAME=$(basename $1)
-  
+
   if [ ! -f "$FNAME" ]; then
     wget $URI
   fi
@@ -19,7 +19,7 @@ if ! which apt-add-repository; then
 fi
 
 if ! which frcmake; then
-  apt-add-repository ppa:wpilib/toolchain 
+  apt-add-repository ppa:wpilib/toolchain
   apt update
   apt install -y frc-toolchain frcmake
 fi
@@ -55,7 +55,7 @@ done
 
 popd
 
-download https://github.com/Itseez/opencv/archive/${OPENCV_VERSION}.tar.gz
+download https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.tar.gz
 
 if [ ! -d opencv-${OPENCV_VERSION} ]; then
   tar -xf ${OPENCV_VERSION}.tar.gz


### PR DESCRIPTION
Fixes #4 

> Changes for compiling OpenCV 3.3.0 for RoboRio.
> 
> *.sh Changes:
> - OPENCV_VERSION variable changed to 3.3.0
> - GitHub user "Itseez" is old, changed to "opencv"
> 
> Dependency Changes:
> - Numpy wheel is discontinued. Using ipkg instead.
> 
> build.sh Changes:
> - removed wheel unpacking (not needed after numpy ipkg)
> - Commented out JAVA_HOME, not needed for compilation
> - fixed OpenCV-*.tar.gz move command